### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__
 build
 *.pyc
-
+*.egg-info

--- a/py2nb/converter.py
+++ b/py2nb/converter.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from IPython.nbformat.v3 import nbpy
-from IPython import nbformat as nbf
+from nbformat.v3 import nbpy
+import nbformat as nbf
 
 from io import StringIO
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name="py2nb",


### PR DESCRIPTION
Fixes
```
.../IPython/nbformat.py:13: ShimWarning: The `IPython.nbformat` package has been deprecated since IPython 4.0. You should import from nbformat instead.
```
and
```
DEPRECATION: Uninstalling a distutils installed project (py2nb) has been deprecated and will be removed in a future version. This is due to the fact that uninstalling a distutils project will only partially uninstall the project.
```

Also adds `*.egg-info` to `.gitignore`